### PR TITLE
Convert mediator config to json

### DIFF
--- a/generator-mediator-js/app/templates/_register.js
+++ b/generator-mediator-js/app/templates/_register.js
@@ -47,6 +47,7 @@ exports.registerMediator = function(apiConfig, mediatorConfig){
 
     // define request headers with auth credentails
     var options = {
+      json: true,
       headers: { 'auth-username': username,
                   'auth-ts': body.ts,
                   'auth-salt': body.salt,


### PR DESCRIPTION
Validation is failing when trying to register mediators because the json is not being handled properly.
