### PR TITLE
Use Node.js native crypto module

### DIFF
--- a/generator-mediator-js/app/templates/_package.json
+++ b/generator-mediator-js/app/templates/_package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "express": "^4.10.0",
     "needle": "^0.7.10",
-    "crypto": "0.0.3",
     "grunt": "^0.4.5",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-express": "^1.4.1"


### PR DESCRIPTION
The crypto module hasn't been updated in over 4 years and Node has its own crypto module. It's a drop in replacement so just removing the dependency is enough.
